### PR TITLE
Remove environment from standard tags

### DIFF
--- a/services/data_stores/mysql/locals.tf
+++ b/services/data_stores/mysql/locals.tf
@@ -2,7 +2,6 @@ locals {
 
   # Standardised tags which are required
   standard_tags = {
-    Environment = "Staging"
     IAC = "terraform"
   }
 }

--- a/services/web_cluster/locals.tf
+++ b/services/web_cluster/locals.tf
@@ -21,7 +21,6 @@ locals {
   # Standardised tags which are required
   standard_tags = {
     Name = var.cluster_name
-    Environment = "Staging"
     IAC = "terraform"
   }
 }


### PR DESCRIPTION
## What
Removing the environment tag from standard module tags

## Why
That would create conflicts if I want to merge staging to master and would override environment tags leading to prod using staging environment tag
Env tag to be defined as custom tag by template using the module